### PR TITLE
Deploy monitoring URL can go directly to the deployment

### DIFF
--- a/farmer/api.py
+++ b/farmer/api.py
@@ -58,7 +58,7 @@ class VMFarmsAPIClient(object):
         """
         Construct a version-appropriate API URL for the given path.
         """
-        path = list(path)
+        path = [str(item) for item in path]
         # Empty string ensures trailing slash.
         path.append('')
         return urljoin(self.url, '/'.join(path))

--- a/farmer/commands/deploy.py
+++ b/farmer/commands/deploy.py
@@ -23,11 +23,12 @@ def cli(app, environment, open_deploy):
     config = load_config()
     try:
         client = VMFarmsAPIClient.from_config(config)
-        deploy_url = client.url_for('builds', 'deploys')
         application_list = client.get('applications')['results']
         selected_application = next(application for application in application_list if application['name'] == app)
         assert environment in selected_application['environments'], 'Invalid environment specified.'
-        client.post('applications/{application_id}/builds'.format(**selected_application), data={'environment': environment})
+        response = client.post('applications/{application_id}/builds'.format(**selected_application), data={'environment': environment})
+        build_id = response['id']
+        deploy_url = client.url_for('builds', 'deploys', build_id)
     except AssertionError as exc:
         output.die(str(exc))
     except StopIteration:


### PR DESCRIPTION
With the recent API update, we can now send users directly to the deployment page in the portal.